### PR TITLE
fix breaking change in latest zarr versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "pandas>=1.1.3",
   "tifffile>=2022.4.22",
   "xarray>=0.16.1",
-  "zarr>=2.6", # for tifffile
+  "zarr>=2.6,<3.0.0", # for tifffile
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "pandas>=1.1.3",
   "tifffile>=2022.4.22",
   "xarray>=0.16.1",
+  #zarr pinned since breaking changes in 3.0 are available with python 3.11
   "zarr>=2.6,<3.0.0", # for tifffile
 ]
 


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #https://github.com/bioio-devs/bioio-tiff-glob/issues/10

### Description of Changes

Do not let zarr installs go up to or past the breaking change in 3.0.0
